### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/api/aiRoutes.js
+++ b/api/aiRoutes.js
@@ -49,7 +49,13 @@ router.get('/files', checkAdmin, (req, res) => {
 router.post('/analyze', checkAdmin, (req, res) => {
   const { filePath } = req.body;
   console.log('Analyzing file:', filePath);
-  fs.readFile(filePath, 'utf8', async (err, data) => {
+  const rootDirectory = path.join(process.cwd(), 'project-files');
+  const resolvedPath = path.resolve(rootDirectory, filePath);
+  if (!resolvedPath.startsWith(rootDirectory)) {
+    console.error('Invalid file path:', filePath);
+    return res.status(403).send('Forbidden');
+  }
+  fs.readFile(resolvedPath, 'utf8', async (err, data) => {
     if (err) {
       console.error('Unable to read file:', err);
       return res.status(500).send('Unable to read file');


### PR DESCRIPTION
Potential fix for [https://github.com/puminosas/audio-description-magic/security/code-scanning/7](https://github.com/puminosas/audio-description-magic/security/code-scanning/7)

To fix the problem, we need to validate the `filePath` to ensure it does not allow path traversal outside a designated safe directory. We can achieve this by resolving the path to its absolute form and checking that it is within a predefined root directory. This approach ensures that any `..` segments are removed, and the path is contained within the intended directory.

1. Define a root directory where the files are expected to be located.
2. Resolve the `filePath` to its absolute form using `path.resolve`.
3. Check that the resolved path starts with the root directory path.
4. If the check fails, return a 403 Forbidden response.
5. If the check passes, proceed with reading the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
